### PR TITLE
Crude fix for unnecessary prompting

### DIFF
--- a/src/kanban-application.c
+++ b/src/kanban-application.c
@@ -27,6 +27,8 @@
 #include "gtk/gtkshortcut.h"
 #include "kanban-window.h"
 
+bool SaveNeeded, IsInitialized = false;
+
 struct _KanbanApplication
 {
 	AdwApplication parent_instance;
@@ -112,39 +114,42 @@ static void response(AdwMessageDialog *self, gchar *response,
   if (strstr(response, "cancel"))
     return;
 
-  GApplication *app = G_APPLICATION(user_data);
+  if (strstr (response, "save"))
+    {
+      save_cards (user_data);
+      SaveNeeded = false;
+    }
+
+  GApplication *app = G_APPLICATION(gtk_window_get_application(GTK_WINDOW (user_data)));
   g_application_quit(app);
 }
 
-// Note to others: The last step in QoL improvement was to include prompt even for leaving the app, should there be unsaved changes,
-// since I've often encountered that I would forget to save, and thus there is no warning, resulting in sighes and rewrites.
+// Crude solution, should however finally fix the unnecessary prompting
 static gboolean save_before_quit(KanbanApplication *self) {
   GtkWindow *window = gtk_application_get_active_window(GTK_APPLICATION(self));
-  // TODO: Need a way to get a condition to check against to not have to constantly prompt for save
-
-  /* if (!need_to_save) {
-    return false;
-  } */
 
   GtkWidget *dialog;
 
-  dialog = adw_message_dialog_new(GTK_WINDOW(window), ("Quick check!"), NULL);
+  dialog = adw_message_dialog_new (window, ("Save Changes?"), NULL);
 
-  adw_message_dialog_format_body(
-      ADW_MESSAGE_DIALOG(dialog),
-      ("Have you saved, or do you want to make further changes, or quit now?"));
+  adw_message_dialog_format_body (ADW_MESSAGE_DIALOG (dialog),
+                                ("Open document contains unsaved changes. Changes which are not saved will be permanently lost."));
 
-  adw_message_dialog_add_responses(ADW_MESSAGE_DIALOG(dialog), "cancel",
-                                   ("_Cancel"), "quit", ("_Quit"), NULL);
+  adw_message_dialog_add_responses (ADW_MESSAGE_DIALOG (dialog),
+                                  "cancel",  ("_Cancel"),
+                                  "discard",  ("_Discard"),
+                                  "save", ("_Save & Quit"),
+                                  NULL);
 
-  adw_message_dialog_set_response_appearance(
-      ADW_MESSAGE_DIALOG(dialog), "quit", ADW_RESPONSE_DESTRUCTIVE);
-  adw_message_dialog_set_default_response(ADW_MESSAGE_DIALOG(dialog), "cancel");
-  adw_message_dialog_set_close_response(ADW_MESSAGE_DIALOG(dialog), "cancel");
+  adw_message_dialog_set_response_appearance (ADW_MESSAGE_DIALOG (dialog), "discard", ADW_RESPONSE_DESTRUCTIVE);
+  adw_message_dialog_set_response_appearance (ADW_MESSAGE_DIALOG (dialog), "save", ADW_RESPONSE_SUGGESTED);
 
-  g_signal_connect(dialog, "response", G_CALLBACK(response), self);
+  adw_message_dialog_set_default_response (ADW_MESSAGE_DIALOG (dialog), "cancel");
+  adw_message_dialog_set_close_response (ADW_MESSAGE_DIALOG (dialog), "cancel");
 
-  gtk_window_present(GTK_WINDOW(dialog));
+  g_signal_connect (dialog, "response", G_CALLBACK (response), window);
+
+  gtk_window_present (GTK_WINDOW (dialog));
 
   return TRUE;
 }
@@ -158,9 +163,11 @@ kanban_application_quit_action (GSimpleAction *action,
 
 	g_assert (KANBAN_IS_APPLICATION (self));
 
+    if (!SaveNeeded) {
+      g_application_quit(G_APPLICATION(self));
+  } 
+  
   save_before_quit(self);
-
-  // g_application_quit(G_APPLICATION(self)); Disabled until further changes
 }
 static void
 kanban_application_save_action (GSimpleAction *action,
@@ -174,6 +181,7 @@ kanban_application_save_action (GSimpleAction *action,
         KanbanWindow* Window = KANBAN_WINDOW (gtk_application_get_active_window (GTK_APPLICATION (self)));
 
         save_cards (Window);
+        SaveNeeded = false;
 }
 static void
 kanban_application_new_action (GSimpleAction *action,

--- a/src/kanban-application.h
+++ b/src/kanban-application.h
@@ -24,6 +24,8 @@
 
 G_BEGIN_DECLS
 
+extern bool SaveNeeded, IsInitialized;
+
 #define KANBAN_TYPE_APPLICATION (kanban_application_get_type())
 
 G_DECLARE_FINAL_TYPE (KanbanApplication, kanban_application, KANBAN, APPLICATION, AdwApplication)

--- a/src/kanban-card.c
+++ b/src/kanban-card.c
@@ -27,6 +27,7 @@
 #include "glib-object.h"
 #include "glib.h"
 #include "gtk/gtk.h"
+#include "kanban-application.h"
 #include "kanban-column.h"
 #include "kanban-window.h"
 #include "utils/kanban-serializer.h"
@@ -205,8 +206,8 @@ delete_clicked(GtkButton* btn, gpointer user_data)
   GtkWidget *old_scrollWnd  = gtk_widget_get_parent(old_view);
   KanbanColumn *old_col     = KANBAN_COLUMN (gtk_widget_get_parent (old_scrollWnd));
 
-  // Until now, we need a condition to not prompt save if nothing got changed
   g_object_set(user_data, "needs-saving", 1, NULL);
+  SaveNeeded = true;
   kanban_column_remove_card(old_col, user_data);
 }
 
@@ -282,13 +283,18 @@ static void
 kanban_card_changed(GtkTextBuffer* buf, gpointer user_data)
 {
     g_object_set (G_OBJECT(user_data), "needs-saving", 1, NULL);
+    if (IsInitialized) {
+      SaveNeeded = true;
+    }
 }
 
 static void
 kanban_card_title_changed(GtkEditableLabel* label, gpointer user_data)
 {
   g_object_set(user_data, "needs-saving", 1, NULL);
-
+  if (IsInitialized) {
+    SaveNeeded = true;
+  }
 }
 
 static GdkContentProvider *

--- a/src/kanban-column.c
+++ b/src/kanban-column.c
@@ -21,6 +21,7 @@
 #include "kanban-column.h"
 #include "config.h"
 #include "gtk/gtk.h"
+#include "kanban-application.h"
 #include "kanban-card.h"
 #include <json-glib/json-glib.h>
 
@@ -229,6 +230,9 @@ static void kanban_column_class_init(KanbanColumnClass *klass) {
 }
 static void title_changed(GtkEditableLabel *label, gpointer user_data) {
   g_object_set(user_data, "needs-saving", 1, NULL);
+  if (IsInitialized) {
+    SaveNeeded = true;
+  }
 }
 
 static void kanban_column_init(KanbanColumn *self) {

--- a/src/kanban-window.c
+++ b/src/kanban-window.c
@@ -21,6 +21,7 @@
 #include "config.h"
 
 #include "kanban-window.h"
+#include "kanban-application.h"
 #include "kanban-column.h"
 #include "json-glib/json-glib.h"
 
@@ -91,6 +92,7 @@ save_cards(gpointer user_data)
   adw_toast_overlay_add_toast (wnd->toast_overlay, adw_toast_new ("Saved"));
 
   gtk_widget_set_sensitive (GTK_WIDGET (wnd->save), false);
+  SaveNeeded = false;
   g_free(file_path);
   g_free (data);
 
@@ -108,7 +110,10 @@ response (AdwMessageDialog* self, gchar* response, gpointer user_data)
     return;
 
   if (strstr (response, "save"))
+  {
     save_cards (user_data);
+    SaveNeeded = false;
+  }
 
   GApplication* app = G_APPLICATION (gtk_window_get_application (GTK_WINDOW (user_data)));
   g_application_quit (app);
@@ -310,6 +315,7 @@ load_ui(KanbanWindow* self)
 
   g_free(file_path);
 
+  IsInitialized = true;
   return FALSE;
 }
 


### PR DESCRIPTION
I have implemented a crude solution, so that now the save prompts are same, regardless if leaving by mouse or by shortcut, getting rid of unnecessary prompts, and also not being able to save in that same old prompt.

I was thinking, we could have `save_before_quit` and `response` as part of a header so that it doesn't have to be copied by original code. What do you think? Other than that, it's a step forward :)