### PR TITLE
Automatically open card for edits after creation

### DIFF
--- a/src/kanban-column.c
+++ b/src/kanban-column.c
@@ -165,6 +165,7 @@ static void add_card_clicked(GtkButton *btn, gpointer user_data) {
   g_object_bind_property(Column, "needs-saving", card, "needs-saving",
                          G_BINDING_BIDIRECTIONAL);
   add_card(Column, card);
+  kanban_card_set_reveal(card, true);
 }
 
 static void kanban_get_property(GObject *object, guint property_id,


### PR DESCRIPTION
called reveal function at the end of the add_card_clicked function so the newly created card may be edited immediately

change built on Fedora and everything seems to be working fine

no AI used... if that's important