### PR TITLE
chore(flatpak): bump runtime to GNOME 49

### DIFF
--- a/io.github.zhrexl.thisweekinmylife.json
+++ b/io.github.zhrexl.thisweekinmylife.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "io.github.zhrexl.thisweekinmylife",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "47",
+    "runtime-version" : "49",
     "sdk" : "org.gnome.Sdk",
     "command" : "thisweekinmylife",
     "finish-args" : [
@@ -32,7 +32,7 @@
                 {
                     "type" : "git",
                     "url" : "https://github.com/zhrexl/ThisWeekInMyLife.git",
-                    "branch": "main"
+                    "branch" : "main"
                 }
             ]
         }


### PR DESCRIPTION
Bumps org.gnome.Platform/org.gnome.Sdk from 47 to 49.

Needed for the ns-resize hover cursor on the card-resize handle
(see companion PR) to render - drag-to-resize itself already works
on 47.