### PR TITLE
Feat/resize cards

### DIFF
--- a/src/kanban-card.c
+++ b/src/kanban-card.c
@@ -34,9 +34,6 @@
 
 static GParamSpec *needs_saving = NULL;
 
-#define KANBAN_CARD_MIN_CONTENT_HEIGHT 80
-#define KANBAN_CARD_MAX_CONTENT_HEIGHT 600
-
 struct _KanbanCard
 {
   GtkListBoxRow      parent_instance;

--- a/src/kanban-card.c
+++ b/src/kanban-card.c
@@ -34,6 +34,9 @@
 
 static GParamSpec *needs_saving = NULL;
 
+#define KANBAN_CARD_MIN_CONTENT_HEIGHT 80
+#define KANBAN_CARD_MAX_CONTENT_HEIGHT 600
+
 struct _KanbanCard
 {
   GtkListBoxRow      parent_instance;
@@ -42,10 +45,14 @@ struct _KanbanCard
   GtkEditableLabel  *LblCardName;
   GtkRevealer       *revealercard;
   GtkRevealer       *drop_revealer;
+  GtkBox            *revealContent;
+  GtkWidget         *resizeHandle;
   GtkTextView       *description;
   AdwButtonContent  *BtnContent;
   guint              description_changed;
   gboolean           needs_saving;
+  gint               drag_start_height;
+  gdouble            drag_start_y_stable;
 };
 
 const gchar checktemplate[] = "<task status=";
@@ -101,6 +108,21 @@ kanban_card_set_reveal(KanbanCard* card, gboolean revealed)
   }
 
   gtk_revealer_set_reveal_child (card->revealercard, revealed);
+}
+
+gint
+kanban_card_get_description_height(KanbanCard* Card)
+{
+  int width, height;
+  gtk_widget_get_size_request (GTK_WIDGET (Card->revealContent), &width, &height);
+  return height;
+}
+
+void
+kanban_card_set_description_height(KanbanCard* Card, gint height)
+{
+  height = CLAMP (height, KANBAN_CARD_MIN_CONTENT_HEIGHT, KANBAN_CARD_MAX_CONTENT_HEIGHT);
+  gtk_widget_set_size_request (GTK_WIDGET (Card->revealContent), -1, height);
 }
 
 /* the user must unref the returned pointer with g_bytes_unref() */
@@ -260,6 +282,10 @@ kanban_card_class_init (KanbanCardClass *klass)
                                         KanbanCard, description);
   gtk_widget_class_bind_template_child (widget_class,
                                         KanbanCard, BtnContent);
+  gtk_widget_class_bind_template_child (widget_class,
+                                        KanbanCard, revealContent);
+  gtk_widget_class_bind_template_child (widget_class,
+                                        KanbanCard, resizeHandle);
 
   gtk_widget_class_bind_template_callback (GTK_WIDGET_CLASS (klass),
                                            reveal_clicked);
@@ -362,10 +388,71 @@ on_drag_begin (GtkDragSource *source,
 
 
 static void
+resize_drag_begin (GtkGestureDrag *gesture,
+                    gdouble         start_x,
+                    gdouble         start_y,
+                    gpointer        user_data)
+{
+  KanbanCard *self = KANBAN_CARD (user_data);
+  graphene_point_t start_point, stable_point;
+
+  /* Prevents the ancestor GtkDragSource from grabbing this drag. */
+  gtk_gesture_set_state (GTK_GESTURE (gesture), GTK_EVENT_SEQUENCE_CLAIMED);
+
+  self->drag_start_height = kanban_card_get_description_height (self);
+
+  /* Use card coordinates, not resizeHandle's - the handle moves as we
+   * resize, which would make the reference point oscillate. */
+  graphene_point_init (&start_point, start_x, start_y);
+
+  /* resizeHandle is always a template child of self, so they always share
+   * an ancestor; failure here would mean the widget tree is broken. */
+  g_return_if_fail (gtk_widget_compute_point (self->resizeHandle, GTK_WIDGET (self),
+                                               &start_point, &stable_point));
+  self->drag_start_y_stable = stable_point.y;
+}
+
+static void
+resize_drag_update (GtkGestureDrag *gesture,
+                     gdouble         offset_x,
+                     gdouble         offset_y,
+                     gpointer        user_data)
+{
+  KanbanCard *self = KANBAN_CARD (user_data);
+  gdouble start_x, start_y;
+  graphene_point_t cur_point, cur_point_stable;
+
+  gtk_gesture_drag_get_start_point (gesture, &start_x, &start_y);
+
+  /* Translate to the same card coordinates as drag_start_y_stable. */
+  graphene_point_init (&cur_point, start_x + offset_x, start_y + offset_y);
+  g_return_if_fail (gtk_widget_compute_point (self->resizeHandle, GTK_WIDGET (self),
+                                               &cur_point, &cur_point_stable));
+
+  kanban_card_set_description_height (self,
+      self->drag_start_height + (gint) (cur_point_stable.y - self->drag_start_y_stable));
+}
+
+static void
+resize_drag_end (GtkGestureDrag *gesture,
+                  gdouble         offset_x,
+                  gdouble         offset_y,
+                  gpointer        user_data)
+{
+  KanbanCard *self = KANBAN_CARD (user_data);
+
+  g_object_set (self, "needs-saving", 1, NULL);
+  if (IsInitialized) {
+    SaveNeeded = true;
+  }
+}
+
+static void
 kanban_card_init (KanbanCard *self)
 {
   GtkDragSource *source;
   GtkDropControllerMotion *motion = NULL;
+  GtkGestureDrag *resize_gesture;
   GtkTextBuffer* buf;
 
   gtk_widget_init_template (GTK_WIDGET (self));
@@ -390,4 +477,13 @@ kanban_card_init (KanbanCard *self)
 
   g_signal_connect(self->LblCardName, "changed", G_CALLBACK(kanban_card_title_changed), self);
   // Both the description and the title are separate, so we had to implement them independently
+
+  resize_gesture = GTK_GESTURE_DRAG (gtk_gesture_drag_new ());
+  gtk_widget_add_controller (self->resizeHandle,
+                             GTK_EVENT_CONTROLLER (resize_gesture));
+  g_signal_connect (resize_gesture, "drag-begin", G_CALLBACK (resize_drag_begin), self);
+  g_signal_connect (resize_gesture, "drag-update", G_CALLBACK (resize_drag_update), self);
+  g_signal_connect (resize_gesture, "drag-end", G_CALLBACK (resize_drag_end), self);
+
+  gtk_widget_set_cursor_from_name (self->resizeHandle, "ns-resize");
 }

--- a/src/kanban-card.h
+++ b/src/kanban-card.h
@@ -28,6 +28,10 @@ G_BEGIN_DECLS
 
 G_DECLARE_FINAL_TYPE (KanbanCard, kanban_card, KANBAN, CARD, GtkListBoxRow)
 
+#define KANBAN_CARD_MIN_CONTENT_HEIGHT     80
+#define KANBAN_CARD_MAX_CONTENT_HEIGHT     600
+#define KANBAN_CARD_DEFAULT_CONTENT_HEIGHT 150
+
 KanbanCard *kanban_card_new(void);
 
 void

--- a/src/kanban-card.h
+++ b/src/kanban-card.h
@@ -50,4 +50,10 @@ void kanban_card_content_dropped(KanbanCard* self);
 void
 kanban_card_set_description(KanbanCard* Card,const gchar* description);
 
+gint
+kanban_card_get_description_height(KanbanCard* Card);
+
+void
+kanban_card_set_description_height(KanbanCard* Card, gint height);
+
 G_END_DECLS

--- a/src/kanban-card.ui
+++ b/src/kanban-card.ui
@@ -86,7 +86,7 @@
             <child>
               <object class="GtkRevealer" id="revealercard">
               <child>
-                <object class="GtkBox">
+                <object class="GtkBox" id="revealContent">
                   <property name="orientation">vertical</property>
                   <property name="vexpand-set">true</property>
                   <property name="height-request">150</property>
@@ -134,6 +134,16 @@
                           <signal name="clicked" handler="insert_checkbox" object="description" swapped="no"/>
                         </object>
                       </child>
+                    </object>
+                  </child>
+                  <child>
+                    <object class="GtkBox" id="resizeHandle">
+                      <property name="halign">center</property>
+                      <property name="height-request">10</property>
+                      <property name="tooltip-text">Drag to resize</property>
+                      <style>
+                        <class name="resize-handle"/>
+                      </style>
                     </object>
                   </child>
                 </object>

--- a/src/kanban-card.ui
+++ b/src/kanban-card.ui
@@ -89,6 +89,7 @@
                 <object class="GtkBox" id="revealContent">
                   <property name="orientation">vertical</property>
                   <property name="vexpand-set">true</property>
+                  <!-- Keep in sync with KANBAN_CARD_DEFAULT_CONTENT_HEIGHT in kanban-card.h -->
                   <property name="height-request">150</property>
                   <child>
                     <object class="GtkSeparator"></object>

--- a/src/kanban-column.c
+++ b/src/kanban-column.c
@@ -97,6 +97,8 @@ void kanban_column_get_json(KanbanColumn *Column, gpointer CardObject) {
       json_object_set_string_member(nested, "description", description);
       json_object_set_int_member(nested, "revealed",
                                  kanban_card_get_reveal(item));
+      json_object_set_int_member(nested, "description_height",
+                                 kanban_card_get_description_height(item));
       json_object_set_object_member(object, kanban_card_get_title(item),
                                     nested);
 
@@ -139,13 +141,19 @@ void kanban_column_remove_card(KanbanColumn *Column, gpointer card) {
   kanban_column_set_needs_saving(Column, true);
 }
 
-void kanban_column_add_new_card(KanbanColumn *Column, const gchar *title,
-                                const gchar *description, gboolean revealed) {
+void
+kanban_column_add_new_card (KanbanColumn *Column,
+                            const gchar  *title,
+                            const gchar  *description,
+                            gboolean      revealed,
+                            gint          description_height)
+{
   KanbanCard *card = kanban_card_new();
 
   kanban_card_set_title(card, title);
   kanban_card_set_description(card, description);
   kanban_card_set_reveal(card, revealed);
+  kanban_card_set_description_height(card, description_height);
 
   add_card(Column, card);
 

--- a/src/kanban-column.h
+++ b/src/kanban-column.h
@@ -46,7 +46,11 @@ kanban_column_remove_card(KanbanColumn* Column, gpointer card);
 void kanban_column_get_json(KanbanColumn* Column, gpointer CardObject);
 
 void
-kanban_column_add_new_card(KanbanColumn* Column, const gchar* title, const gchar* description, gboolean revealed);
+kanban_column_add_new_card (KanbanColumn *Column,
+                            const gchar  *title,
+                            const gchar  *description,
+                            gboolean      revealed,
+                            gint          description_height);
 
 void kanban_column_insert_card(KanbanColumn *Column, double y, gpointer card);
 

--- a/src/kanban-window.c
+++ b/src/kanban-window.c
@@ -23,6 +23,7 @@
 #include <glib/gi18n.h>
 
 #include "kanban-application.h"
+#include "kanban-card.h"
 #include "kanban-column.h"
 #include "json-glib/json-glib.h"
 
@@ -265,8 +266,12 @@ void create_cards_from_json(KanbanColumn* Column, JsonNode* node)
     const gchar*  description = json_object_get_string_member (objmember,
                                                               "description");
     gboolean revealed = json_object_get_boolean_member (objmember, "revealed");
+    gint description_height = KANBAN_CARD_DEFAULT_CONTENT_HEIGHT;
+    if (json_object_has_member (objmember, "description_height"))
+      description_height = json_object_get_int_member (objmember, "description_height");
 
-    kanban_column_add_new_card (Column, objectname, description, revealed);
+    kanban_column_add_new_card (Column, objectname, description, revealed,
+                                description_height);
   }
 
   g_list_free(list);

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -22,3 +22,16 @@
     background-color: rgba(252, 228, 134,0.75);
 }
 
+.resize-handle
+{
+    min-width: 64px;
+    margin-bottom: 4px;
+    border-radius: 3px;
+    background-color: rgba(0, 0, 0, 0.2);
+}
+
+.resize-handle:hover
+{
+    background-color: rgba(0, 0, 0, 0.4);
+}
+


### PR DESCRIPTION
Adds a drag handle to resize each card's description area; height
persists across save/reload.

Depends on the GNOME 49 runtime bump (see PR#52) for the resize
cursor to render - dragging itself works on GNOME 47 too.